### PR TITLE
adminパスワード変更のコマンド実装 

### DIFF
--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -442,6 +442,13 @@ set_storage_credentials(){
   STORAGE_PASSWORD=$STORAGE_PASSWORD ./deploy-kqi-app.sh credentials
   # Podを再起動
   kubectl rollout restart deploy minio --namespace kqi-system
+
+  echo "ストレージの認証情報を更新しました"
+  echo "KAMONOHASHIのDBに保管されているストレージの接続情報をストレージ管理画面から適宜変更してください"
+}
+
+set_platypus_credentials(){
+  echo "KAMONOHASHIのAdminユーザのパスワードについてはユーザ管理画面から適宜変更してください"
 }
 
 set_db_credentials(){
@@ -464,6 +471,8 @@ set_db_credentials(){
   # Podを再起動
   kubectl rollout restart deploy postgres --namespace kqi-system
   kubectl rollout restart deploy platypus-web-api --namespace kqi-system
+
+  echo "DBの認証情報を更新しました"
 }
 
 set_credentials(){
@@ -478,6 +487,7 @@ set_credentials(){
 
       set_db_credentials $PASSWORD
       set_storage_credentials $PASSWORD
+      set_platypus_credentials
       ;;
     *)
       show_unknown_arg "credentials" "storage, db, all" $1 ;;

--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -432,7 +432,7 @@ update(){
 set_db_credentials(){
   cd $HELM_DIR
   if [ -z "$1" ]; then
-    echo -en "\n\e[33mDB Passwordを入力: \e[m"; read -s DB_PASSWORD
+    echo -en "\e[33m新しいDB Passwordを入力: \e[m"; read -s DB_PASSWORD
     echo "" # read -s は改行しないため、echoで改行
   else
     DB_PASSWORD=$1
@@ -450,13 +450,13 @@ set_db_credentials(){
   kubectl rollout restart deploy postgres --namespace kqi-system
   kubectl rollout restart deploy platypus-web-api --namespace kqi-system
 
-  echo "DBの認証情報を更新しました"
+  echo -e "\nDBの認証情報を更新しました"
 }
 
 set_storage_credentials(){
   cd $HELM_DIR
   if [ -z "$1" ]; then
-    echo -en "\n\e[33mStorage Secret Keyを入力: \e[m"; read -s STORAGE_PASSWORD
+    echo -en "\e[33m新しいStorage Secret Keyを入力: \e[m"; read -s STORAGE_PASSWORD
     echo "" # read -s は改行しないため、echoで改行
   else
     STORAGE_PASSWORD=$1
@@ -467,12 +467,12 @@ set_storage_credentials(){
   # Podを再起動
   kubectl rollout restart deploy minio --namespace kqi-system
 
-  echo "ストレージの認証情報を更新しました"
+  echo -e "\nストレージの認証情報を更新しました"
   echo "KAMONOHASHIのDBに保管されているストレージの接続情報をストレージ管理画面から適宜変更してください"
 }
 
 set_platypus_credentials(){
-  echo "KAMONOHASHIのAdminユーザのパスワードについてはユーザ管理画面から適宜変更してください"
+  echo -e "\nKAMONOHASHIのAdminユーザのパスワードについてはユーザ管理画面から適宜変更してください"
 }
 
 set_credentials(){
@@ -482,7 +482,7 @@ set_credentials(){
     db)
       set_db_credentials ;;
     all)
-      echo -en "Admin Passwordを入力: "; read -s PASSWORD
+      echo -en "\e[33m新しいAdmin Passwordを入力: \e[m"; read -s PASSWORD
       echo "" # read -s は改行しないため、echoで改行
 
       set_db_credentials $PASSWORD

--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -439,7 +439,7 @@ set_db_credentials(){
   fi
 
   # PostgreDBのPod名を取得
-  POD_NAME=`kubectl get pods --no-headers -o custom-columns=":metadata.name" --namespace kqi-system | grep postgres`
+  POD_NAME=$(kubectl get pods --namespace kqi-system | grep postgres | awk '{print $1}')
   # Pod内でSQLコマンド実行
   kubectl exec $POD_NAME -it --namespace kqi-system -- /bin/sh -c "\
     psql -U platypus -d platypusdb -w -c \"ALTER USER platypus WITH PASSWORD '$DB_PASSWORD'\";

--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -429,28 +429,6 @@ update(){
 #  credentials関連
 ############
 
-set_storage_credentials(){
-  cd $HELM_DIR
-  if [ -z "$1" ]; then
-    echo -en "\n\e[33mStorage Secret Keyを入力: \e[m"; read -s STORAGE_PASSWORD
-    echo "" # read -s は改行しないため、echoで改行
-  else
-    STORAGE_PASSWORD=$1
-  fi
-
-  # credentials更新
-  STORAGE_PASSWORD=$STORAGE_PASSWORD ./deploy-kqi-app.sh credentials
-  # Podを再起動
-  kubectl rollout restart deploy minio --namespace kqi-system
-
-  echo "ストレージの認証情報を更新しました"
-  echo "KAMONOHASHIのDBに保管されているストレージの接続情報をストレージ管理画面から適宜変更してください"
-}
-
-set_platypus_credentials(){
-  echo "KAMONOHASHIのAdminユーザのパスワードについてはユーザ管理画面から適宜変更してください"
-}
-
 set_db_credentials(){
   cd $HELM_DIR
   if [ -z "$1" ]; then
@@ -473,6 +451,28 @@ set_db_credentials(){
   kubectl rollout restart deploy platypus-web-api --namespace kqi-system
 
   echo "DBの認証情報を更新しました"
+}
+
+set_storage_credentials(){
+  cd $HELM_DIR
+  if [ -z "$1" ]; then
+    echo -en "\n\e[33mStorage Secret Keyを入力: \e[m"; read -s STORAGE_PASSWORD
+    echo "" # read -s は改行しないため、echoで改行
+  else
+    STORAGE_PASSWORD=$1
+  fi
+
+  # credentials更新
+  STORAGE_PASSWORD=$STORAGE_PASSWORD ./deploy-kqi-app.sh credentials
+  # Podを再起動
+  kubectl rollout restart deploy minio --namespace kqi-system
+
+  echo "ストレージの認証情報を更新しました"
+  echo "KAMONOHASHIのDBに保管されているストレージの接続情報をストレージ管理画面から適宜変更してください"
+}
+
+set_platypus_credentials(){
+  echo "KAMONOHASHIのAdminユーザのパスワードについてはユーザ管理画面から適宜変更してください"
 }
 
 set_credentials(){

--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -468,7 +468,7 @@ set_storage_credentials(){
   kubectl rollout restart deploy minio --namespace kqi-system
 
   echo -e "\nストレージの認証情報を更新しました"
-  echo "KAMONOHASHIのDBに保管されているストレージの接続情報をストレージ管理画面から適宜変更してください"
+  echo "KAMONOHASHIのDBに保管されているストレージの接続情報はストレージ管理画面から適宜変更してください"
 }
 
 set_platypus_credentials(){

--- a/deploy-kamonohashi.sh
+++ b/deploy-kamonohashi.sh
@@ -416,23 +416,18 @@ update_kube_certs(){
   kubeadm alpha certs renew all
 }
 
-set_credentials(){
+update(){
   case $1 in
-    storage)
-      update_storage_password ;;
-    db)
-      update_db_password ;;
-    all)
-      echo -en "Admin Passwordを入力: "; read -s PASSWORD
-      echo "" # read -s は改行しないため、echoで改行
-
-      set_storage_credentials $PASSWORD
-      set_db_credentials $PASSWORD
-      ;;
-    *)
-      show_unknown_arg "password" "storage, db, all" $1 ;;
+    app) update_app ;;
+    node-conf) update_node_conf ${@:2} ;;
+    kube-certs) update_kube_certs;;
+    *) show_unknown_arg "update" "app, node-conf, kube-certs" $1 ;;
   esac
 }
+
+############
+#  credentials関連
+############
 
 set_storage_credentials(){
   cd $HELM_DIR
@@ -471,17 +466,23 @@ set_db_credentials(){
   kubectl rollout restart deploy platypus-web-api --namespace kqi-system
 }
 
-update(){
+set_credentials(){
   case $1 in
-    app) update_app ;;
-    node-conf) update_node_conf ${@:2} ;;
-    kube-certs) update_kube_certs;;
-    credentials) set_credentials ${@:2};;
-    *) show_unknown_arg "update" "app, node-conf, kube-certs, credentials" $1 ;;
+    storage)
+      set_storage_credentials ;;
+    db)
+      set_db_credentials ;;
+    all)
+      echo -en "Admin Passwordを入力: "; read -s PASSWORD
+      echo "" # read -s は改行しないため、echoで改行
+
+      set_db_credentials $PASSWORD
+      set_storage_credentials $PASSWORD
+      ;;
+    *)
+      show_unknown_arg "credentials" "storage, db, all" $1 ;;
   esac
 }
-
-
 
 ############
 #  check関連
@@ -523,13 +524,14 @@ Usage: ./deploy-kamonohashi.sh COMMAND [ARGS] [OPTIONS]
   KAMONOHASHI デプロイスクリプト: ${THIS_SCRIPT_VER}
 
 Commands:
-  prepare    構築に利用するツールのインストールを行います
-  configure  構築の設定を行います
-  deploy     構築します
-  update     アプリのアップデートまたはクラスタ設定の更新反映を行います
-  clean      アンインストールします
-  check      デプロイの状態確認を行います
-  help       このヘルプを表示します
+  prepare     構築に利用するツールのインストールを行います
+  configure   構築の設定を行います
+  deploy      構築します
+  update      アプリのアップデートまたはクラスタ設定の更新反映を行います
+  clean       アンインストールします
+  credentials 認証情報の設定を行います
+  check       デプロイの状態確認を行います
+  help        このヘルプを表示します
 
 詳細は ${HELP_URL} で確認してください
 
@@ -550,6 +552,7 @@ main(){
     deploy) deploy ${@:2};;
     update) update ${@:2};;
     clean) clean ${@:2};;
+    credentials) set_credentials ${@:2};;
     check) check ${@:2};;
     help) show_help ;;
     *) show_help ;;

--- a/kamonohashi/charts/kamonohashi-credentials/templates/credentials.yml
+++ b/kamonohashi/charts/kamonohashi-credentials/templates/credentials.yml
@@ -28,7 +28,7 @@ metadata:
     app.kubernetes.io/managed-by: helm
 type: Opaque
 data:
-  MINIO_SECRET_KEY: "{{.Values.storage_secretkey | b64enc}}"
+  MINIO_ROOT_PASSWORD: "{{.Values.storage_secretkey | b64enc}}"
 ---
 apiVersion: v1
 kind: Secret

--- a/kamonohashi/charts/kamonohashi/templates/minio.yml
+++ b/kamonohashi/charts/kamonohashi/templates/minio.yml
@@ -35,7 +35,7 @@ spec:
         volumeMounts:
         - name: nfs-data
           mountPath: "/data"
-        image: minio/minio:RELEASE.2020-03-09T18-26-53Z
+        image: minio/minio:RELEASE.2021-12-10T23-03-39Z
         args:
         - gateway
         - nas

--- a/kamonohashi/charts/kamonohashi/templates/minio.yml
+++ b/kamonohashi/charts/kamonohashi/templates/minio.yml
@@ -41,7 +41,7 @@ spec:
         - nas
         - /data
         env:
-        - name: MINIO_ACCESS_KEY
+        - name: MINIO_ROOT_USER
           value: {{.Values.appsettings.DeployOptions__ObjectStorageAccessKey}}
         envFrom:
         - secretRef:

--- a/kamonohashi/deploy-kqi-app.sh
+++ b/kamonohashi/deploy-kqi-app.sh
@@ -6,15 +6,22 @@ show_help() {
     echo "available args: prepare, deploy, clean, update, credentials, upgrade, help"
 }
 
-
-set_credentials(){   
+set_credentials(){
     kubectl apply -f kqi-namespace.yml
-    if [ -z "$PASSWORD" ] || [ -z "$DB_PASSWORD" ] || [ -z "$STORAGE_PASSWORD" ]; then
-      echo -en "\e[33mAdmin Passwordを入力: \e[m"; read -s PASSWORD
-      echo -en "\n\e[33mDB Passwordを入力: \e[m"; read -s DB_PASSWORD
-      echo -en "\n\e[33mStorage Secret Keyを入力: \e[m"; read -s STORAGE_PASSWORD
-      echo "" # read -sは改行しないので改行 
-    fi  
+    # パスワードが未指定のものは、既にSecretに設定されているパスワードを設定する
+    if [ -z "$PASSWORD" ]; then
+      PASSWORD=`kubectl get secret --namespace kqi-system platypus-web-api-env-secret -o jsonpath="{.data.DeployOptions__Password}" | base64 --decode` 
+    fi
+    if [ -z "$DB_PASSWORD" ]; then
+      DB_PASSWORD=`kubectl get secret --namespace kqi-system postgres-credential -o jsonpath="{.data.POSTGRES_PASSWORD}" | base64 --decode`
+    fi
+    if [ -z "$STORAGE_PASSWORD" ]; then
+      STORAGE_PASSWORD=`kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_ROOT_PASSWORD}" | base64 --decode`
+      # MinIOが以前のバージョンだと環境変数名は"MINIO_SECRET_KEY"なので、そこからパスワードを取得する
+      if [ -z "$STORAGE_PASSWORD" ]; then
+        STORAGE_PASSWORD=`kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_SECRET_KEY}" | base64 --decode`
+      fi
+    fi
     SET_ARGS="password=$PASSWORD,db_password=$DB_PASSWORD,storage_secretkey=$STORAGE_PASSWORD"
     helm upgrade kamonohashi-credentials charts/kamonohashi-credentials -i --set $SET_ARGS --namespace kqi-system
 }

--- a/kamonohashi/deploy-kqi-app.sh
+++ b/kamonohashi/deploy-kqi-app.sh
@@ -10,16 +10,16 @@ set_credentials(){
     kubectl apply -f kqi-namespace.yml
     # パスワードが未指定のものは、既にSecretに設定されているパスワードを設定する
     if [ -z "$PASSWORD" ]; then
-      PASSWORD=`kubectl get secret --namespace kqi-system platypus-web-api-env-secret -o jsonpath="{.data.DeployOptions__Password}" | base64 --decode` 
+      PASSWORD=$(kubectl get secret --namespace kqi-system platypus-web-api-env-secret -o jsonpath="{.data.DeployOptions__Password}" | base64 --decode)
     fi
     if [ -z "$DB_PASSWORD" ]; then
-      DB_PASSWORD=`kubectl get secret --namespace kqi-system postgres-credential -o jsonpath="{.data.POSTGRES_PASSWORD}" | base64 --decode`
+      DB_PASSWORD=$(kubectl get secret --namespace kqi-system postgres-credential -o jsonpath="{.data.POSTGRES_PASSWORD}" | base64 --decode)
     fi
     if [ -z "$STORAGE_PASSWORD" ]; then
-      STORAGE_PASSWORD=`kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_ROOT_PASSWORD}" | base64 --decode`
+      STORAGE_PASSWORD=$(kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_ROOT_PASSWORD}" | base64 --decode)
       # MinIOが以前のバージョンだと環境変数名は"MINIO_SECRET_KEY"なので、そこからパスワードを取得する
       if [ -z "$STORAGE_PASSWORD" ]; then
-        STORAGE_PASSWORD=`kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_SECRET_KEY}" | base64 --decode`
+        STORAGE_PASSWORD=$(kubectl get secret --namespace kqi-system minio-credential -o jsonpath="{.data.MINIO_SECRET_KEY}" | base64 --decode)
       fi
     fi
     SET_ARGS="password=$PASSWORD,db_password=$DB_PASSWORD,storage_secretkey=$STORAGE_PASSWORD"


### PR DESCRIPTION
以下の２つのコマンドを実装する。
・PostgreSQLのadminパスワード変更
・MinIOのadminパスワード変更

Kamonohashiのデータベース内部で保持しているMinIOのパスワードについては、ユーザ側の操作で変更する方針とする。